### PR TITLE
Hide cards from folded players

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -765,10 +765,12 @@ pub(crate) fn completed_game(state: &state::State) -> Option<models::CompletedGa
         .players
         .values()
         .map(|p| {
+(!p.folded).then(|| {
             (
                 (p.cards.0.suite.clone(), p.cards.0.value.clone()),
                 (p.cards.1.suite.clone(), p.cards.1.value.clone()),
             )
+})
         })
         .collect()
     };

--- a/src/game.rs
+++ b/src/game.rs
@@ -78,7 +78,7 @@ pub(crate) fn start_game(state: &mut state::State) -> Result<(), String> {
 
     state.round.cards_on_table.clear();
     state.round.pot = 0;
-state.round.folded = false;
+    state.round.folded = false;
     reset_players(state);
     next_turn(state, None);
     if state.status == state::GameStatus::Complete {
@@ -750,11 +750,11 @@ pub(crate) fn completed_game(state: &state::State) -> Option<models::CompletedGa
         (x, _) if x.len() == 0 => None,
         (cards_on_table, _) => Some(
             state
-        .players
-        .values()
-        .map(|p| (p, cards::Card::evaluate_hand(&p.cards, &cards_on_table)))
+                .players
+                .values()
+                .map(|p| (p, cards::Card::evaluate_hand(&p.cards, &cards_on_table)))
                 .map(|(p, score)| (p.name.as_str(), score))
-        .max_by_key(|(_, score)| *score)?,
+                .max_by_key(|(_, score)| *score)?,
         ),
     };
 
@@ -762,17 +762,17 @@ pub(crate) fn completed_game(state: &state::State) -> Option<models::CompletedGa
         vec![]
     } else {
         state
-        .players
-        .values()
-        .map(|p| {
-(!p.folded).then(|| {
-            (
-                (p.cards.0.suite.clone(), p.cards.0.value.clone()),
-                (p.cards.1.suite.clone(), p.cards.1.value.clone()),
-            )
-})
-        })
-        .collect()
+            .players
+            .values()
+            .map(|p| {
+                (!p.folded).then(|| {
+                    (
+                        (p.cards.0.suite.clone(), p.cards.0.value.clone()),
+                        (p.cards.1.suite.clone(), p.cards.1.value.clone()),
+                    )
+                })
+            })
+            .collect()
     };
 
     Some(models::CompletedGame {
@@ -833,7 +833,7 @@ pub(crate) fn fold_player(
             let pot = state.round.pot;
             only_player_left.balance += pot;
             state.round.pot = 0;
-state.round.folded = true;
+            state.round.folded = true;
 
             state
                 .ticker
@@ -1117,7 +1117,7 @@ mod tests {
 
         let completed = completed_game(&state).unwrap();
         assert_eq!(completed.winning_hand, None);
-assert_eq!(completed.player_cards.len(), 0);
+        assert_eq!(completed.player_cards.len(), 0);
     }
 
     #[test]

--- a/src/models.rs
+++ b/src/models.rs
@@ -68,7 +68,7 @@ pub(crate) struct GameClientRoom {
 pub(crate) struct CompletedGame {
     pub(crate) winner_name: Option<String>,
     pub(crate) winning_hand: Option<String>,
-    pub(crate) player_cards: Vec<((CardSuite, CardValue), (CardSuite, CardValue))>,
+    pub(crate) player_cards: Vec<Option<((CardSuite, CardValue), (CardSuite, CardValue))>>,
 }
 
 #[derive(Debug, Serialize, schemars::JsonSchema)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -37,6 +37,7 @@ pub struct Round {
     pub players_turn: Option<PlayerId>,
     pub raises: Vec<(PlayerId, u64)>,
     pub calls: Vec<(PlayerId, u64)>,
+    pub folded: bool,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
- Excludes player cards from big-screen polling state for players that have folded out of a round
- Prevents all player cards from big-screen polling state if game has ended early due to folding