### PR TITLE
feat: ballot system, kick player or double blinds

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -49,6 +49,8 @@ pub(crate) struct GamePlayerState {
     pub(crate) turn_expires_dt: Option<u64>,
     pub(crate) last_update: u64,
     pub(crate) current_round_stake: u64,
+    pub(crate) ballot_details: Option<BallotDetails>,
+    pub(crate) start_ballot_options: Option<StartBallotChoices>,
 }
 
 #[derive(Debug, Serialize, schemars::JsonSchema)]
@@ -88,4 +90,43 @@ pub(crate) enum GamePhase {
     Waiting,
     Playing,
     Complete,
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum BallotAction {
+    DoubleBlinds,
+    KickPlayer(String),
+}
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema, Clone)]
+pub struct KickPlayerOption {
+    pub name: String,
+    pub id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema, Clone)]
+pub struct StartBallotChoices {
+    pub kick_player: Vec<KickPlayerOption>,
+    pub double_blinds: bool,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CastVoteRequest {
+    pub(crate) player_id: String,
+    pub(crate) vote: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BallotDetails {
+    pub(crate) action: BallotAction,
+    pub(crate) expires_dt: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct StartBallot {
+    pub(crate) action: BallotAction,
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -209,6 +209,7 @@ pub(crate) struct BallotDetails {
 #[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct StartBallot {
+    pub(crate) room_code: String,
     pub(crate) action: BallotAction,
 }
 


### PR DESCRIPTION
Initial implementation of the voting system with kicking players and doubling blinds

* Add new endpoints: start ballot, and cast vote
* Add Some(ballot) to state
* At end of vote (all votes or timeout), add the action to queue
* Process actions at the end of each round

To check:

- [ ] If two players try to start ballots at the same time, does it only accept the first one or overwrite the original one?