### PR TITLE
Unlimited rooms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a41e6f1c1c057d2f77f8e694168841cec1752986348c1b8f20518d2d01a606d"
 dependencies = [
  "axum 0.7.4",
+ "axum-extra",
  "bytes",
  "cfg-if",
  "derive_more",
@@ -158,6 +159,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
+dependencies = [
+ "axum 0.7.4",
+ "axum-core 0.4.3",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +197,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +213,15 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bytes"
@@ -209,6 +248,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +277,16 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -248,6 +316,8 @@ version = "0.1.0"
 dependencies = [
  "aide",
  "axum 0.7.4",
+ "axum-extra",
+ "headers",
  "rand",
  "schemars",
  "serde",
@@ -363,6 +433,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +483,30 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http 1.1.0",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.1.0",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -896,6 +1000,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1258,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aide = { version = "0.13.3", features = ["axum", "redoc", "scalar", "axum-multipart"] }
+aide = { version = "0.13.3", features = ["axum", "scalar", "axum-multipart", "axum-headers"] }
 axum = { version = "0.7.4", features = ["multipart"] }
+axum-extra = { version = "0.9.3", features = ["typed-header"] }
+headers = "0.4.0"
 rand = "0.8.5"
 schemars = "0.8.16"
 serde = { version = "1.0.197", features = ["derive"] }

--- a/src/cards.rs
+++ b/src/cards.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, fmt::Display};
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Deck(Vec<Card>);
 
 impl Deck {

--- a/src/doc_routes.rs
+++ b/src/doc_routes.rs
@@ -6,7 +6,6 @@ use aide::{
         ApiRouter, IntoApiResponse,
     },
     openapi::OpenApi,
-    redoc::Redoc,
     scalar::Scalar,
 };
 use axum::{Extension, Json};
@@ -27,16 +26,6 @@ pub fn docs_routes(state: SharedState) -> ApiRouter {
             "/",
             get_with(
                 Scalar::new("/docs/private/api.json")
-                    .with_title("Aide Axum")
-                    .axum_handler(),
-                |op| op.description("This documentation page."),
-            ),
-            |p| p.security_requirement("ApiKey"),
-        )
-        .api_route_with(
-            "/redoc",
-            get_with(
-                Redoc::new("/docs/private/api.json")
                     .with_title("Aide Axum")
                     .axum_handler(),
                 |op| op.description("This documentation page."),

--- a/src/game.rs
+++ b/src/game.rs
@@ -28,7 +28,7 @@ pub(crate) fn spawn_game_worker(state: state::SharedState) {
         let idle_ms = match status {
             state::GameStatus::Joining => Some(state::GAME_IDLE_TIMEOUT_SECONDS * 1000),
             state::GameStatus::Complete => Some(state::GAME_IDLE_TIMEOUT_SECONDS * 1000 * 4),
-            state::GameStatus::Playing => None,
+            state::GameStatus::Playing | state::GameStatus::Idle => None,
         };
 
         if idle_ms.map_or(false, |idle_ms| now_ms - last_update > idle_ms) {
@@ -136,7 +136,7 @@ pub(crate) fn add_new_player(
     if state.players.len() >= state::MAX_PLAYERS {
         return Err("Room is full".to_string());
     }
-    
+
     let player_name = player_name.replace(char::is_whitespace, " ");
     let player_name = player_name.trim().to_owned();
     if player_name.is_empty() {
@@ -766,6 +766,7 @@ pub(crate) fn game_phase(state: &state::State) -> models::GamePhase {
         state::GameStatus::Joining => models::GamePhase::Waiting,
         state::GameStatus::Playing => models::GamePhase::Playing,
         state::GameStatus::Complete => models::GamePhase::Complete,
+        state::GameStatus::Idle => models::GamePhase::Idle,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ use std::{
 
 use aide::{axum::ApiRouter, openapi::OpenApi, transform::TransformOpenApi};
 use axum::Extension;
-use tokio::sync::RwLock;
 use tower_http::cors::CorsLayer;
 use tracing::info;
 
@@ -29,8 +28,7 @@ async fn main() {
     let mut api = OpenApi::default();
 
     // initialize state
-    let state = state::State::default();
-    let state: state::SharedState = Arc::new(RwLock::new(state));
+    let state = state::SharedState::default();
     game::spawn_game_worker(state.clone());
 
     // build our application with a route

--- a/src/models.rs
+++ b/src/models.rs
@@ -6,12 +6,32 @@ use crate::cards::{CardSuite, CardValue};
 #[serde(rename_all = "camelCase")]
 pub(crate) struct JoinRequest {
     pub(crate) name: String,
+    pub(crate) room_code: Option<String>,
 }
 
 #[derive(Debug, Serialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct JoinResponse {
     pub(crate) id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NewRoomRequest {
+    pub(crate) name: String,
+}
+
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NewRoomResponse {
+    pub(crate) id: String,
+    pub(crate) room_code: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CloseRoomRequest {
+    pub(crate) room_code: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -86,6 +106,7 @@ pub(crate) struct GameClientRoom {
     pub(crate) cards: Vec<(CardSuite, CardValue)>,
     pub(crate) completed: Option<CompletedGame>,
     pub(crate) ticker: Option<String>,
+    pub(crate) room_code: Option<String>,
     pub(crate) last_update: u64,
 }
 
@@ -104,6 +125,7 @@ pub(crate) struct GameClientPlayer {
     pub(crate) balance: u64,
     pub(crate) folded: bool,
     pub(crate) photo: Option<String>,
+    pub(crate) color_hue: u16,
     pub(crate) turn_expires_dt: Option<u64>,
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -45,7 +45,7 @@ pub(crate) struct PeekRoomRequest {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PeekRoomResponse {
     pub(crate) state: GamePhase,
-    pub(crate) player_count: usize,
+    pub(crate) players_count: usize,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -106,6 +106,7 @@ pub(crate) struct GamePlayerState {
     pub(crate) your_turn: bool,
     pub(crate) call_amount: u64,
     pub(crate) min_raise_to: u64,
+    pub(crate) players_count: usize,
     pub(crate) turn_expires_dt: Option<u64>,
     pub(crate) last_update: u64,
     pub(crate) current_round_stake: u64,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, OnceLock},
-};
+use std::sync::{Arc, OnceLock};
 
 use crate::{
     game, models,
@@ -50,18 +47,7 @@ pub(crate) fn api_routes(state: state::SharedState) -> ApiRouter {
         .api_route("/new", post_with(new_room, docs::new_room))
         .api_route("/join", post_with(join, docs::join))
         .api_route("/play", post_with(play, docs::play))
-        .api_route("/dump", get_with(dump, docs::dump))
         .with_state(state)
-}
-
-pub(crate) async fn dump(State(state): State<SharedState>) -> JsonResult<HashMap<String, String>> {
-    let state: Vec<_> = state.iter_key_values().await.collect();
-    let mut map = HashMap::new();
-    for (room_code, room_state) in state {
-        let room_state = room_state.read().await;
-        map.insert(room_code.to_string(), format!("{:?}", &*room_state));
-    }
-    Ok(Json(map))
 }
 
 pub(crate) async fn room(

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -645,8 +645,4 @@ pub mod docs {
     pub fn reset_room(op: TransformOperation) -> TransformOperation {
         op.description("Reset the game room.")
     }
-
-    pub fn dump(op: TransformOperation) -> TransformOperation {
-        op.description("Dump all room game states.")
-    }
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -386,7 +386,6 @@ pub(crate) async fn join(
         .await
         .ok_or(StatusCode::NOT_FOUND)?;
     let mut state = state.write().await;
-    info!("Received room state for room = {:?}", room_code);
 
     let id = match game::add_new_player(&mut state, &payload.name, player_id) {
         Ok(id) => id,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -117,6 +117,7 @@ pub(crate) async fn player(
         your_turn: game::is_player_turn(&state, &player.id),
         call_amount: game::call_amount(&state).unwrap_or(0),
         min_raise_to: game::min_raise_to(&state),
+        players_count: state.players.len(),
         turn_expires_dt: game::turn_expires_dt(&state, &player.id),
         last_update: state.last_update.as_u64(),
         current_round_stake: game::player_stake_in_round(&state, &player.id),
@@ -455,7 +456,7 @@ pub(crate) async fn peek_room(
 
     let peek = models::PeekRoomResponse {
         state: game::game_phase(&state),
-        player_count: state.players.len(),
+        players_count: state.players.len(),
     };
 
     Ok(Json(peek))

--- a/src/state.rs
+++ b/src/state.rs
@@ -103,7 +103,7 @@ impl SharedState {
     }
 
     pub async fn cleanup(&self) {
-        let mut rooms = self.states.write().unwrap();
+        let mut rooms = self.states.write().unwrap().clone();
         let mut to_remove = Vec::new();
 
         for (room_code, state) in rooms.iter() {
@@ -115,7 +115,7 @@ impl SharedState {
 
             let now = Instant::default().as_u64();
             let last_update = state.last_update.as_u64();
-            let room_expires_at = last_update + GAME_IDLE_CLEANUP_SECONDS * 1000;
+            let room_expires_at = last_update + GAME_IDLE_TIMEOUT_SECONDS * 1000;
 
             if room_expires_at < now {
                 to_remove.push(room_code.clone());
@@ -232,14 +232,11 @@ pub mod room {
             if char_count != ROOM_CODE_LENGTH {
                 return Err(());
             }
-            if !s
-                .chars()
-                .all(|c| c.is_ascii_alphabetic() && c.is_uppercase())
-            {
+            if !s.chars().all(|c| c.is_ascii_alphabetic()) {
                 return Err(());
             }
 
-            Ok(Self(s.to_string()))
+            Ok(Self(s.to_ascii_uppercase()))
         }
     }
 
@@ -266,7 +263,6 @@ pub const TICKER_ITEM_TIMEOUT_SECONDS: u64 = 10;
 pub const TICKER_ITEM_GAP_MILLISECONDS: u64 = 500;
 pub const PLAYER_TURN_TIMEOUT_SECONDS: u64 = 60;
 pub const GAME_IDLE_TIMEOUT_SECONDS: u64 = 300;
-pub const GAME_IDLE_CLEANUP_SECONDS: u64 = 30;
 pub const ROOM_CODE_LENGTH: usize = 4;
 pub const MAX_PLAYERS: usize = 10;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -287,6 +287,12 @@ pub struct Round {
     pub completed: Option<CompletedRound>,
 }
 
+impl Into<RoomState> for State {
+    fn into(self) -> RoomState {
+        Arc::new(RwLock::new(self))
+    }
+}
+
 #[derive(Clone)]
 pub struct PlayerPhoto(pub Arc<Bytes>, pub token::Token);
 
@@ -330,6 +336,7 @@ pub enum GameStatus {
     Joining,
     Playing,
     Complete,
+    Idle,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
The server maintains a registry of rooms and the individually synchronised state object for each room. Rooms can be looked up in the registry by `player_id`, so the API stays mostly the same - with the main exception of creating and joining rooms (note: some other room management endpoints now accept a header `room-code`, these cases are documented in openapi)