### PR TITLE
Resume player session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "axum 0.7.4",
  "axum-core 0.4.3",
  "bytes",
+ "cookie",
  "futures-util",
  "headers",
  "http 1.1.0",
@@ -293,6 +294,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ aide = { version = "0.13.3", features = [
     "axum-headers",
 ] }
 axum = { version = "0.7.4", features = ["multipart"] }
-axum-extra = { version = "0.9.3", features = ["typed-header"] }
+axum-extra = { version = "0.9.3", features = ["cookie", "typed-header"] }
 headers = "0.4.0"
 rand = "0.8.5"
 schemars = "0.8.16"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 use aide::{axum::ApiRouter, openapi::OpenApi, transform::TransformOpenApi};
-use axum::Extension;
+use axum::{
+    middleware::{map_request, map_response},
+    Extension,
+};
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
 pub mod cards;
@@ -18,6 +21,8 @@ pub fn create_application(state: state::SharedState) -> axum::Router {
         .route("/health", axum::routing::get(|| async { "ok" }))
         .nest_api_service("/api/v1", routes::api_routes(state.clone()))
         .nest_api_service("/docs", doc_routes::docs_routes(state.clone()))
+        .layer(map_response(layer::write_response_apid_cookie))
+        .layer(map_request(layer::ensure_request_apid_cookie))
         .finish_api_with(&mut api, api_docs)
         .layer(Extension(Arc::new(api)))
         .layer(CorsLayer::permissive())
@@ -28,4 +33,72 @@ fn api_docs(api: TransformOpenApi) -> TransformOpenApi {
     api.title("flop: The Party Poker Game")
         .summary("API for poker game")
         .description(include_str!("../README.md"))
+}
+
+pub mod layer {
+    use axum::{
+        extract::FromRequestParts,
+        http::{Request, Response, StatusCode},
+        Extension,
+    };
+    use axum_extra::extract::{cookie::Cookie, CookieJar};
+
+    use inner::SetApidCookie;
+
+    #[derive(Clone)]
+    pub struct Apid(pub String);
+
+    pub mod inner {
+        #[derive(Clone)]
+        pub struct SetApidCookie(pub uuid::Uuid);
+    }
+
+    pub async fn ensure_request_apid_cookie<B>(
+        request: Request<B>,
+    ) -> Result<Request<B>, StatusCode> {
+        let (mut parts, body) = request.into_parts();
+        let cookies = CookieJar::from_request_parts(&mut parts, &())
+            .await
+            .map_err(|_| StatusCode::BAD_REQUEST)?;
+
+        let apid_cookie = cookies
+            .get("apid")
+            .filter(|cookie| uuid::Uuid::parse_str(cookie.value_trimmed()).is_ok());
+
+        match apid_cookie {
+            Some(cookie) => {
+                let apid = cookie.value_trimmed().to_string();
+                parts.extensions.insert(Apid(apid));
+            }
+            None => {
+                let uuid = uuid::Uuid::new_v4();
+                let apid = uuid.to_string();
+                parts.extensions.insert(Apid(apid));
+                parts.extensions.insert(SetApidCookie(uuid));
+            }
+        }
+
+        Ok(Request::from_parts(parts, body))
+    }
+
+    pub async fn write_response_apid_cookie<B>(
+        extension: Option<Extension<SetApidCookie>>,
+        mut response: Response<B>,
+    ) -> Response<B> {
+        match extension {
+            Some(Extension(SetApidCookie(apid))) => {
+                let cookie = Cookie::build(("apid", apid.to_string()))
+                    .path("/")
+                    // .secure(true)
+                    .http_only(true);
+
+                response
+                    .headers_mut()
+                    .insert("Set-Cookie", cookie.to_string().parse().unwrap());
+
+                response
+            }
+            None => response,
+        }
+    }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -22,6 +22,19 @@ pub(crate) struct NewRoomRequest {
     pub(crate) name: String,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ResumeRequest {
+    pub(crate) room_code: Option<String>,
+}
+
+#[derive(Debug, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ResumeResponse {
+    pub(crate) id: String,
+    pub(crate) name: String,
+}
+
 #[derive(Debug, Serialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct NewRoomResponse {
@@ -46,6 +59,8 @@ pub(crate) struct PeekRoomRequest {
 pub(crate) struct PeekRoomResponse {
     pub(crate) state: GamePhase,
     pub(crate) players_count: usize,
+    pub(crate) can_resume: bool,
+    pub(crate) resume_player_name: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -457,6 +457,13 @@ pub(crate) async fn resume(
                 _ = shared_state
                     .join_room(&player.id, req_room_code.as_ref())
                     .await;
+
+                state
+                    .players
+                    .get_mut(&player.id)
+                    .expect("player not found")
+                    .folded = true;
+
                 Some(player)
             }
             None => state.players.get_non_dormant(&apid).cloned(),

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, OnceLock};
 
 use crate::{
-    game, models,
+    game, layer, models,
     state::{self, SharedState},
 };
 
@@ -13,7 +13,7 @@ use axum::{
     body,
     extract::{Multipart, Path, Query, State},
     http::{header, HeaderValue, StatusCode},
-    Json,
+    Extension, Json,
 };
 use axum_extra::TypedHeader;
 use tracing::info;
@@ -27,6 +27,10 @@ pub(crate) fn api_routes(state: state::SharedState) -> ApiRouter {
         .api_route("/room/close", post_with(close_room, docs::close_room))
         .api_route("/room/reset", post_with(reset_room, docs::reset_room))
         .api_route("/player/:player_id", get_with(player, docs::player))
+        .api_route(
+            "/player/:player_id/leave",
+            post_with(player_leave, docs::player_leave),
+        )
         .api_route(
             "/player/:player_id/send",
             post_with(player_send, docs::player_send),
@@ -46,6 +50,7 @@ pub(crate) fn api_routes(state: state::SharedState) -> ApiRouter {
         )
         .api_route("/new", post_with(new_room, docs::new_room))
         .api_route("/join", post_with(join, docs::join))
+        .api_route("/resume", post_with(resume, docs::resume))
         .api_route("/play", post_with(play, docs::play))
         .with_state(state)
 }
@@ -116,6 +121,28 @@ pub(crate) async fn player(
     };
 
     Ok(Json(game_player_state))
+}
+
+pub(crate) async fn player_leave(
+    State(state): State<SharedState>,
+    Path(player_id): Path<String>,
+) -> JsonResult<()> {
+    let player = utils::validate_player(&player_id, &state).await?;
+    let shared_state = state.clone();
+    let state = state.get(&player.id).await.ok_or(StatusCode::NOT_FOUND)?;
+    let mut state = state.write().await;
+
+    game::remove_player(&mut state, &player.id).map_err(|err| {
+        info!("Player {} failed to leave: {}", player_id, err);
+        StatusCode::BAD_REQUEST
+    })?;
+
+    shared_state.remove(&player.id).await;
+
+    state.last_update.set_now();
+    info!("Player {} left", player_id);
+
+    Ok(Json(()))
 }
 
 pub(crate) async fn player_send(
@@ -349,6 +376,7 @@ pub(crate) async fn play(
 
 pub(crate) async fn join(
     State(state): State<SharedState>,
+    Extension(layer::Apid(apid)): Extension<layer::Apid>,
     Json(payload): Json<models::JoinRequest>,
 ) -> JsonResult<models::JoinResponse> {
     if payload.name.is_empty()
@@ -370,10 +398,10 @@ pub(crate) async fn join(
         .await
         .map_err(|_| {
             info!(
-                "Player failed to join room: room code = {:?}, player id = {}",
+                "Player failed to join room, room not found: room code = {:?}, player id = {}",
                 req_room_code, player_id
             );
-            StatusCode::BAD_REQUEST
+            StatusCode::NOT_FOUND
         })?;
     info!("Player {} joined room = {:?}", player_id, room_code);
     let state = state
@@ -390,17 +418,60 @@ pub(crate) async fn join(
         }
     };
 
+    game::set_player_apid(&mut state, &id, &apid);
+
     state.last_update.set_now();
 
-    info!("Player {} joined", id);
+    info!("Player {} joined with name '{}'", id, payload.name);
     Ok(Json(models::JoinResponse {
         id: id.to_string(),
         room_code: room_code.to_string(),
     }))
 }
 
+pub(crate) async fn resume(
+    State(state): State<SharedState>,
+    Extension(layer::Apid(apid)): Extension<layer::Apid>,
+    Json(payload): Json<models::ResumeRequest>,
+) -> JsonResult<models::ResumeResponse> {
+    info!("Resuming previous session for anonymous player id {}", apid);
+
+    let req_room_code: Option<state::room::RoomCode> = match payload.room_code {
+        Some(room_code) => Some(room_code.parse().map_err(|_| StatusCode::BAD_REQUEST)?),
+        None => None,
+    };
+
+    let room_state = match req_room_code {
+        Some(room_code) => state.get_room(&room_code).await,
+        None => state.get_default_room().await,
+    };
+
+    let room_state = room_state.ok_or(StatusCode::NOT_FOUND)?;
+
+    let mut state = room_state.write().await;
+
+    let player = state
+        .players
+        .promote_dormant(&apid)
+        .or_else(|| state.players.get_non_dormant(&apid).cloned())
+        .ok_or_else(|| StatusCode::NOT_FOUND)?;
+
+    state
+        .ticker
+        .emit(state::TickerEvent::PlayerResumed(player.id));
+    state.last_update.set_now();
+
+    info!("Player {} resumed", player.id);
+
+    Ok(Json(models::ResumeResponse {
+        id: player.id.to_string(),
+        name: player.name,
+    }))
+}
+
 pub(crate) async fn new_room(
     State(state): State<SharedState>,
+    Extension(layer::Apid(apid)): Extension<layer::Apid>,
     Json(payload): Json<models::NewRoomRequest>,
 ) -> JsonResult<models::NewRoomResponse> {
     let player_id = state::PlayerId::default();
@@ -423,9 +494,11 @@ pub(crate) async fn new_room(
         }
     };
 
+    game::set_player_apid(&mut state, &id, &apid);
+
     state.last_update.set_now();
 
-    info!("Player {} joined", id);
+    info!("Player {} joined with name '{}'", id, payload.name);
     Ok(Json(models::NewRoomResponse {
         id: id.to_string(),
         room_code: room_code.to_string(),
@@ -434,14 +507,23 @@ pub(crate) async fn new_room(
 
 pub(crate) async fn peek_room(
     State(state): State<SharedState>,
+    Extension(layer::Apid(apid)): Extension<layer::Apid>,
     Json(payload): Json<models::PeekRoomRequest>,
 ) -> JsonResult<models::PeekRoomResponse> {
     let state = utils::query_room_state(&state, Some(payload.room_code)).await?;
     let state = state.read().await;
 
+    let resume_player_name = state
+        .players
+        .peek_dormant(&apid)
+        .or_else(|| state.players.get_non_dormant(&apid))
+        .map(|p| p.name.clone());
+
     let peek = models::PeekRoomResponse {
         state: game::game_phase(&state),
         players_count: state.players.len(),
+        can_resume: resume_player_name.is_some(),
+        resume_player_name,
     };
 
     Ok(Json(peek))
@@ -604,6 +686,10 @@ pub mod docs {
         op.description("Get the current state of a player.")
     }
 
+    pub fn player_leave(op: TransformOperation) -> TransformOperation {
+        op.description("Leave the game room.")
+    }
+
     pub fn player_send(op: TransformOperation) -> TransformOperation {
         op.description("Send a message to the game room.")
     }
@@ -634,6 +720,10 @@ pub mod docs {
 
     pub fn join(op: TransformOperation) -> TransformOperation {
         op.description("Join the game room.")
+    }
+
+    pub fn resume(op: TransformOperation) -> TransformOperation {
+        op.description("Resume previous session in the game room.")
     }
 
     pub fn peek_room(op: TransformOperation) -> TransformOperation {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -41,22 +41,79 @@ async fn it_should_start_game_and_play_3p_until_end() {
 }
 
 #[tokio::test]
-async fn it_should_remove_player_from_game() {
+async fn it_should_remove_players_from_game_on_leave() {
     let (server, handle) = server::new_mock_app_server();
 
+    //  start game with 3 players
     let mut game = fixtures::start_full_game(&server, 3).await;
     fixtures::play_rounds_until_winner(&server, &game).await;
 
-    client::leave_room(&server, &game.player_ids[0]).await;
-
+    // player 1 leaves
     let leaving_player_id = game.player_ids.remove(0);
+    client::leave_room(&server, &leaving_player_id).await;
+
     client::requests::get_little_screen(&server, &leaving_player_id)
         .expect_failure()
         .await
         .assert_status_not_found();
 
     client::start_game(&server, &game.room_code).await;
+    fixtures::play_round(&server, &game).await;
+
+    // player 3 leaves, only 1 player left
+    let leaving_player_id = game.player_ids.remove(1);
+    client::leave_room(&server, &leaving_player_id).await;
+
+    client::requests::get_little_screen(&server, &leaving_player_id)
+        .expect_failure()
+        .await
+        .assert_status_not_found();
+
+    let status = client::get_big_screen(&server, Some(&game.room_code))
+        .await
+        .state;
+
+    // the game should be stopped and wait for more players
+    assert_eq!(status, "waiting");
+
+    handle.abort().await;
+}
+
+#[tokio::test]
+async fn it_should_not_show_card_of_rejoining_players() {
+    let (server, handle) = server::new_mock_app_server();
+
+    //  start game with 3 players
+    let mut game = fixtures::start_full_game(&server, 3).await;
     fixtures::play_rounds_until_winner(&server, &game).await;
+
+    // player 1 leaves
+    let leaving_player_id = game.player_ids.remove(0);
+    client::leave_room(&server, &leaving_player_id).await;
+
+    // player 1 rejoins
+    let rejoining_player_apid = game.player_apids.get(&leaving_player_id).unwrap();
+    let rejoining_player =
+        client::resume_session(&server, rejoining_player_apid, &game.room_code).await;
+    assert_eq!(rejoining_player.player_id, leaving_player_id);
+
+    let big_screen = client::get_big_screen(&server, Some(&game.room_code)).await;
+    let rejoining_player_idx = big_screen
+        .players
+        .iter()
+        .position(|p| p["name"] == "player1")
+        .unwrap();
+
+    let completed_game = big_screen.raw["completed"]
+        .as_object()
+        .expect("completed is not an object");
+
+    let player_cards = completed_game["playerCards"]
+        .as_array()
+        .expect("player_cards is not an array");
+
+    let rejoining_player_cards = &player_cards[rejoining_player_idx];
+    assert_eq!(rejoining_player_cards, &serde_json::Value::Null);
 
     handle.abort().await;
 }


### PR DESCRIPTION
- Adds an 'anonymous player id' (or 'apid') cookie.
- Allow player to resume their previous stat in a room by calling `/resume` with the same apid cookie.
- Allow player to leave game manually - rather than just timeouts